### PR TITLE
Feature/better event binding

### DIFF
--- a/library/src/main/java/ca/antonious/viewcelladapter/BindListener.java
+++ b/library/src/main/java/ca/antonious/viewcelladapter/BindListener.java
@@ -1,0 +1,16 @@
+package ca.antonious.viewcelladapter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by George on 2016-12-22.
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BindListener {
+    Class value();
+}

--- a/library/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
+++ b/library/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
@@ -87,21 +87,13 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> {
     }
 
     private void bindListeners(BaseViewHolder holder, AbstractViewCell viewCell) {
-        Class<?> viewCellClass = viewCell.getClass();
-
         try {
+            Class<?> viewCellClass = viewCell.getClass();
             Method[] methods = viewCellClass.getDeclaredMethods();
 
             for (Method method: methods) {
                 if (method.isAnnotationPresent(BindListener.class)) {
                     BindListener bindListener = method.getAnnotation(BindListener.class);
-
-                    Class[] paramTypes = method.getParameterTypes();
-                    Class<?> viewHolderParam = paramTypes[0];
-                    Class<?> listenerParam = paramTypes[1];
-
-                    // check params here
-
                     Object listenerInstance = listenerCollection.getListener(bindListener.value());
 
                     if (listenerInstance != null) {
@@ -109,7 +101,6 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> {
                     }
                 }
             }
-
         } catch (Exception e) {
             e.printStackTrace();
             return;

--- a/library/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
+++ b/library/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
@@ -10,7 +10,9 @@ import ca.antonious.viewcelladapter.ListenerCollection;
 public abstract class AbstractViewCell<VH extends BaseViewHolder> {
     public abstract int getLayoutId();
     public abstract int getItemId();
-    public abstract void bindListeners(VH viewHolder, ListenerCollection listeners);
     public abstract void bindViewCell(VH viewHolder);
     public abstract Class<? extends VH> getViewHolderClass();
+
+    @Deprecated
+    public abstract void bindListeners(VH viewHolder, ListenerCollection listeners);
 }


### PR DESCRIPTION
Use runtime reflection to automatically bind listeners to view cells using the `BindListener` annotation. Will most likely be moving to compile time annotation processing to speed up listener binding. Currently `@BindListener` will just assume that the method has params of type 'ViewHolder' and the appropriate listener in the given order, if not the binding will silently fail.