### PR TITLE
Use ViewHolderFactories rather than returning the view holder type to create viewholders

### DIFF
--- a/sample-app/src/main/java/ca/antonious/sample/MainActivity.java
+++ b/sample-app/src/main/java/ca/antonious/sample/MainActivity.java
@@ -100,7 +100,7 @@ public class MainActivity extends AppCompatActivity {
 
         EmptySectionDecorator allWithEmpty = new EmptySectionDecorator(compositeSection, new EmptyViewCell("EMPTY"));
 
-        viewCellAdapter.add(allWithEmpty);
+        viewCellAdapter.add(todaySection);
         viewCellAdapter.addListener(new TaskViewCell.OnTaskClickListener() {
             @Override
             public void onTaskClicked(Task task) {

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
@@ -5,7 +5,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -17,6 +16,7 @@ import ca.antonious.viewcelladapter.utils.CollectionUtils;
 import ca.antonious.viewcelladapter.utils.ViewCellUtils;
 import ca.antonious.viewcelladapter.viewcells.AbstractViewCell;
 import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
+import ca.antonious.viewcelladapter.viewcells.ViewHolderFactory;
 import ca.antonious.viewcelladapter.viewcells.eventhandling.ListenerBinderHelper;
 import ca.antonious.viewcelladapter.viewcells.eventhandling.ListenerCollection;
 
@@ -27,12 +27,12 @@ import ca.antonious.viewcelladapter.viewcells.eventhandling.ListenerCollection;
 public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> {
     private List<AbstractSection> sections;
     private ListenerCollection listenerCollection;
-    private Map<Integer, Class<? extends BaseViewHolder>> layoutTypes;
+    private Map<Integer, ViewHolderFactory> viewHolderFactories;
 
     public ViewCellAdapter() {
         this.sections = new ArrayList<>();
         this.listenerCollection = new ListenerCollection();
-        this.layoutTypes = new HashMap<>();
+        this.viewHolderFactories = new HashMap<>();
     }
 
     public void add(AbstractSection section) {
@@ -61,16 +61,8 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> {
 
     @Override
     public BaseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        try {
-            View view = LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);
-
-            Class<? extends BaseViewHolder> layoutViewHolder = layoutTypes.get(viewType);
-            Constructor<? extends BaseViewHolder> viewHolderConstructor = layoutViewHolder.getConstructor(View.class);
-
-            return viewHolderConstructor.newInstance(view);
-        } catch (Exception e) {
-            return null;
-        }
+        View view = LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);
+        return viewHolderFactories.get(viewType).createViewHolder(view);
     }
 
     @Override
@@ -93,9 +85,9 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> {
         AbstractViewCell viewCell = ViewCellUtils.getViewCell(sections, position);
 
         int itemId = viewCell.getLayoutId();
-        Class<? extends BaseViewHolder> viewHolderClass = viewCell.getViewHolderClass();
+        ViewHolderFactory viewHolderFactory = viewCell.getViewHolderFactory();
 
-        layoutTypes.put(itemId, viewHolderClass);
+        viewHolderFactories.put(itemId, viewHolderFactory);
 
         return itemId;
     }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
@@ -29,5 +29,5 @@ public abstract class AbstractViewCell<VH extends BaseViewHolder> implements Sel
     public abstract int getLayoutId();
     public abstract int getItemId();
     public abstract void bindViewCell(VH viewHolder);
-    public abstract Class<? extends VH> getViewHolderClass();
+    public abstract ViewHolderFactory getViewHolderFactory();
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/GenericViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/GenericViewCell.java
@@ -25,11 +25,4 @@ public abstract class GenericViewCell<VH extends BaseViewHolder, T> extends View
     public int getItemId() {
         return model.hashCode();
     }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public Class<? extends VH> getViewHolderClass() {
-        return (Class<? extends VH>) ((ParameterizedType) getClass()
-                .getGenericSuperclass()).getActualTypeArguments()[0];
-    }
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/ViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/ViewCell.java
@@ -1,9 +1,42 @@
 package ca.antonious.viewcelladapter.viewcells;
 
+import android.view.LayoutInflater;
+import android.view.View;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.ParameterizedType;
+
 /**
  * Created by George on 2016-11-17.
  */
 
 public abstract class ViewCell<VH extends BaseViewHolder> extends AbstractViewCell<VH> {
+    @Override
+    public ViewHolderFactory getViewHolderFactory() {
+        return new ReflectionBasedViewHolderFactory(getViewHolderClass());
+    }
 
+    @SuppressWarnings("unchecked")
+    public Class<? extends VH> getViewHolderClass() {
+        return (Class<? extends VH>) ((ParameterizedType) getClass()
+                .getGenericSuperclass()).getActualTypeArguments()[0];
+    }
+
+    public static class ReflectionBasedViewHolderFactory implements ViewHolderFactory {
+        private Class<? extends BaseViewHolder> viewHolderClass;
+
+        public ReflectionBasedViewHolderFactory(Class<? extends BaseViewHolder> viewHolderClass) {
+            this.viewHolderClass = viewHolderClass;
+        }
+
+        @Override
+        public BaseViewHolder createViewHolder(View view) {
+            try {
+                Constructor<? extends BaseViewHolder> viewHolderConstructor = viewHolderClass.getConstructor(View.class);
+                return viewHolderConstructor.newInstance(view);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+    }
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/ViewHolderFactory.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/ViewHolderFactory.java
@@ -1,0 +1,11 @@
+package ca.antonious.viewcelladapter.viewcells;
+
+import android.view.View;
+
+/**
+ * Created by George on 2016-12-30.
+ */
+
+public interface ViewHolderFactory {
+    BaseViewHolder createViewHolder(View view);
+}


### PR DESCRIPTION
Provide the ability to override how ViewHolders are constructed to provide a faster way to create them.