### PR TITLE
Version 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,16 @@ ViewCellAdapter adapter = ViewCellAdapter.create()
     .build();
 ```
 
+### Using your old adapters
 
+If you have a legacy adapter that is not easy to convert to this library's API you can wrap it in an `AdapterWrapperSection`. This allows you to insert your old adapter as a section in a `ViewCellAdapter`. It also lets you decorate it using any `SectionDecorator`.
+
+```java
+RecyclerView.Adapter legacyTasksAdapter = ...;
+AbstractSection tasksSection = new AdapterWrapperSection<>(legacyTasksAdapter);
+
+// integrate this section with the ViewCellAdapter API
+```
 
 ## Handling ViewHolder Events
 
@@ -249,8 +258,8 @@ viewCellAdapter.addListener(new TaskViewCell.OnTaskClickListener() {
 
 ```groovy
 dependencies {
-    compile 'ca.antonious:viewcelladapter:2.1.0'
-    annotationProcessor 'ca.antonious:viewcelladapter-compiler:2.1.0'
+    compile 'ca.antonious:viewcelladapter:2.2.0'
+    annotationProcessor 'ca.antonious:viewcelladapter-compiler:2.2.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ ViewCellAdapter adapter = ViewCellAdapter.create()
             .header(new HeaderViewCell("Today's Tasks"))
             .hideHeaderIfEmpty()
             .showIfEmpty(new EmptyViewCell("You have no tasks to do today!"))
-            .build()
     )
     .build();
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
     supportLibVersion = "25.3.1"
     userOrg = 'gantonious'
     groupId = 'ca.antonious'
-    publishVersion = '2.1.0'
+    publishVersion = '2.2.0'
     website = "https://github.com/gantonious/ViewCellAdapter"
 }
 

--- a/sample-app/src/main/java/ca/antonious/sample/ComplexDecoratorCompositionSample.java
+++ b/sample-app/src/main/java/ca/antonious/sample/ComplexDecoratorCompositionSample.java
@@ -50,16 +50,13 @@ public class ComplexDecoratorCompositionSample extends BaseActivity {
                         SectionBuilder.wrap(section1)
                             .header(buildHeader("Section 1"))
                             .hideHeaderIfEmpty()
-                            .build()
                     )
                     .section(
                         SectionBuilder.wrap(section2)
                             .header(buildHeader("Section 2"))
                             .hideHeaderIfEmpty()
-                            .build()
                     )
                     .showIfEmpty(new EmptyViewCell("Add items at the top"))
-                    .build()
             )
             .listener(new SampleModelViewCell.OnSampleModelClickListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/GridLayoutSample.java
+++ b/sample-app/src/main/java/ca/antonious/sample/GridLayoutSample.java
@@ -48,18 +48,15 @@ public class GridLayoutSample extends BaseActivity {
                     SectionBuilder.createCompositeSection()
                         .section(
                             SectionBuilder.wrap(section1)
-                                    .header(buildHeader("Section 1"))
-                                    .hideHeaderIfEmpty()
-                                    .build()
+                                .header(buildHeader("Section 1"))
+                                .hideHeaderIfEmpty()
                         )
                         .section(
                             SectionBuilder.wrap(section2)
-                                    .header(buildHeader("Section 2"))
-                                    .hideHeaderIfEmpty()
-                                    .build()
+                                .header(buildHeader("Section 2"))
+                                .hideHeaderIfEmpty()
                         )
                         .showIfEmpty(new EmptyViewCell("Add items at the top"))
-                        .build()
                 )
                 .listener(new SampleModelViewCell.OnSampleModelClickListener() {
                     @Override

--- a/sample-app/src/main/java/ca/antonious/sample/HeterogeneousSample.java
+++ b/sample-app/src/main/java/ca/antonious/sample/HeterogeneousSample.java
@@ -44,7 +44,6 @@ public class HeterogeneousSample extends BaseActivity {
             .section(
                 SectionBuilder.wrap(mainSection)
                     .showIfEmpty(new EmptyViewCell("Add items at the top"))
-                    .build()
             )
             .listener(new SampleModelViewCell.OnSampleModelClickListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/HomeActivity.java
+++ b/sample-app/src/main/java/ca/antonious/sample/HomeActivity.java
@@ -35,7 +35,6 @@ public class HomeActivity extends BaseActivity {
             .section(
                 SectionBuilder.wrap(samplesSection)
                     .separateWithDividers()
-                    .build()
             )
             .listener(new SampleViewCell.OnSampleClickListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/MultipleSectionsSample.java
+++ b/sample-app/src/main/java/ca/antonious/sample/MultipleSectionsSample.java
@@ -44,13 +44,11 @@ public class MultipleSectionsSample extends BaseActivity {
                 SectionBuilder.wrap(importantSection)
                     .header(new HeaderViewCell("Important"))
                     .showHeaderIfEmpty()
-                    .build()
             )
             .section(
                 SectionBuilder.wrap(normalSection)
                     .header(new HeaderViewCell("Normal"))
                     .hideHeaderIfEmpty()
-                    .build()
             )
             .listener(new SampleModelViewCell.OnSampleModelClickListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/SettingsSample.java
+++ b/sample-app/src/main/java/ca/antonious/sample/SettingsSample.java
@@ -47,13 +47,11 @@ public class SettingsSample extends BaseActivity {
                 SectionBuilder.wrap(userSettings)
                     .separateWithDividers()
                     .header(buildHeader("User Settings"))
-                    .build()
             )
             .section(
                 SectionBuilder.wrap(notificationSettings)
                     .separateWithDividers()
                     .header(buildHeader("Notification Settings"))
-                    .build()
             )
             .listener(new MaterialSettingsItemViewCell.OnSettingClickedListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/SortedHomogeneousSectionSample.java
+++ b/sample-app/src/main/java/ca/antonious/sample/SortedHomogeneousSectionSample.java
@@ -47,7 +47,6 @@ public class SortedHomogeneousSectionSample extends BaseActivity {
                         }
                     })
                     .showIfEmpty(new EmptyViewCell("Press the add button to add items!"))
-                    .build()
             )
             .listener(new SampleModelViewCell.OnSampleModelClickListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/about/AboutActivity.java
+++ b/sample-app/src/main/java/ca/antonious/sample/about/AboutActivity.java
@@ -44,7 +44,6 @@ public class AboutActivity extends BaseActivity {
                     .separateWithDividers()
                     .header(new HeaderViewCell("Libraries Used"))
                     .hideHeaderIfEmpty()
-                    .build()
             )
             .listener(new LibraryViewCell.OnLibraryClickListener() {
                 @Override

--- a/sample-app/src/main/java/ca/antonious/sample/viewcells/EmptyViewCell.java
+++ b/sample-app/src/main/java/ca/antonious/sample/viewcells/EmptyViewCell.java
@@ -1,10 +1,10 @@
 package ca.antonious.sample.viewcells;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
 import ca.antonious.sample.R;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 import ca.antonious.viewcelladapter.viewcells.GenericViewCell;
 
 /**
@@ -27,7 +27,7 @@ public class EmptyViewCell extends GenericViewCell<EmptyViewCell.ViewHolder, Str
         viewHolder.setHeaderText(getModel());
     }
 
-    public static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private TextView emptyTextView;
 
         public ViewHolder(View itemView) {

--- a/sample-app/src/main/java/ca/antonious/sample/viewcells/HeaderViewCell.java
+++ b/sample-app/src/main/java/ca/antonious/sample/viewcells/HeaderViewCell.java
@@ -1,10 +1,10 @@
 package ca.antonious.sample.viewcells;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
 import ca.antonious.sample.R;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 import ca.antonious.viewcelladapter.viewcells.GenericViewCell;
 
 /**
@@ -27,7 +27,7 @@ public class HeaderViewCell extends GenericViewCell<HeaderViewCell.ViewHolder, S
         viewHolder.setHeaderText(getModel());
     }
 
-    public static class ViewHolder extends BaseViewHolder {
+    public static class ViewHolder extends RecyclerView.ViewHolder {
         private TextView headerTextView;
 
         public ViewHolder(View itemView) {

--- a/sample-app/src/main/java/ca/antonious/sample/viewcells/SampleModelViewCell.java
+++ b/sample-app/src/main/java/ca/antonious/sample/viewcells/SampleModelViewCell.java
@@ -1,12 +1,12 @@
 package ca.antonious.sample.viewcells;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
 import ca.antonious.sample.R;
 import ca.antonious.sample.models.SampleModel;
 import ca.antonious.viewcelladapter.annotations.BindListener;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 import ca.antonious.viewcelladapter.viewcells.GenericViewCell;
 
 /**
@@ -48,7 +48,7 @@ public class SampleModelViewCell extends GenericViewCell<SampleModelViewCell.Sam
         });
     }
 
-    public static class SampleModelViewHolder extends BaseViewHolder {
+    public static class SampleModelViewHolder extends RecyclerView.ViewHolder {
         private TextView nameTextView;
 
         public SampleModelViewHolder(View itemView) {

--- a/sample-app/src/main/java/ca/antonious/sample/viewcells/SampleViewCell.java
+++ b/sample-app/src/main/java/ca/antonious/sample/viewcells/SampleViewCell.java
@@ -1,12 +1,12 @@
 package ca.antonious.sample.viewcells;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
 import ca.antonious.sample.R;
 import ca.antonious.sample.models.Sample;
 import ca.antonious.viewcelladapter.annotations.BindListener;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 import ca.antonious.viewcelladapter.viewcells.GenericViewCell;
 
 /**
@@ -45,7 +45,7 @@ public class SampleViewCell extends GenericViewCell<SampleViewCell.SampleViewHol
         });
     }
 
-    public static class SampleViewHolder extends BaseViewHolder {
+    public static class SampleViewHolder extends RecyclerView.ViewHolder {
         private TextView titleTextView;
         private TextView descriptionTextView;
 

--- a/sample-app/src/main/java/ca/antonious/sample/viewcells/SelectableModelViewCell.java
+++ b/sample-app/src/main/java/ca/antonious/sample/viewcells/SelectableModelViewCell.java
@@ -1,12 +1,12 @@
 package ca.antonious.sample.viewcells;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
 import ca.antonious.sample.R;
 import ca.antonious.sample.models.SelectableModel;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 import ca.antonious.viewcelladapter.viewcells.GenericViewCell;
 
 /**
@@ -49,7 +49,7 @@ public class SelectableModelViewCell extends GenericViewCell<SelectableModelView
         }
     }
 
-    public static class SelectableModelViewHolder extends BaseViewHolder {
+    public static class SelectableModelViewHolder extends RecyclerView.ViewHolder {
         private TextView nameTextView;
         private CheckBox selectionCheckBox;
 

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
@@ -124,11 +124,4 @@ public class ViewCellAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     public AbstractViewCell get(int position) {
         return ViewCellUtils.getViewCell(sections, position);
     }
-
-    public void remove(int position) {
-        int sectionIndex = ViewCellUtils.getSectionIndex(sections, position);
-        int viewCellIndex = ViewCellUtils.getViewCellIndex(sections, position);
-
-        sections.get(sectionIndex).remove(viewCellIndex);
-    }
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
@@ -1,19 +1,15 @@
 package ca.antonious.viewcelladapter;
 
 import android.support.v7.widget.RecyclerView;
-import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import ca.antonious.viewcelladapter.construction.ViewCellAdapterBuilder;
-import ca.antonious.viewcelladapter.internal.Function;
 import ca.antonious.viewcelladapter.internal.SectionObserver;
 import ca.antonious.viewcelladapter.sections.AbstractSection;
 import ca.antonious.viewcelladapter.utils.CollectionUtils;
@@ -30,13 +26,13 @@ import ca.antonious.viewcelladapter.viewcells.eventhandling.ListenerCollection;
 public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> implements SectionObserver {
     private List<AbstractSection> sections;
     private ListenerCollection listenerCollection;
-    private Map<Integer, Function<View, BaseViewHolder>> viewHolderFactories;
+    private Map<Integer, AbstractViewCell> viewCellTypes;
 
     public ViewCellAdapter() {
         this.setHasStableIds(true);
         this.sections = new ArrayList<>();
         this.listenerCollection = new ListenerCollection();
-        this.viewHolderFactories = new HashMap<>();
+        this.viewCellTypes = new HashMap<>();
     }
 
     public static ViewCellAdapterBuilder create() {
@@ -92,8 +88,7 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> implem
 
     @Override
     public BaseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);
-        return viewHolderFactories.get(viewType).apply(view);
+        return viewCellTypes.get(viewType).createViewHolder(parent);
     }
 
     @Override
@@ -115,12 +110,10 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> implem
     public int getItemViewType(int position) {
         AbstractViewCell viewCell = ViewCellUtils.getViewCell(sections, position);
 
-        int itemId = viewCell.getLayoutId();
-        Function<View, BaseViewHolder> viewHolderFactory = viewCell.getViewHolderFactory();
+        int viewType = viewCell.getViewType();
+        viewCellTypes.put(viewType, viewCell);
 
-        viewHolderFactories.put(itemId, viewHolderFactory);
-
-        return itemId;
+        return viewType;
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
@@ -23,7 +23,7 @@ import ca.antonious.viewcelladapter.viewcells.eventhandling.ListenerCollection;
  * Created by George on 2016-11-15.
  */
 
-public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> implements SectionObserver {
+public class ViewCellAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements SectionObserver {
     private List<AbstractSection> sections;
     private ListenerCollection listenerCollection;
     private Map<Integer, AbstractViewCell> viewCellTypes;
@@ -87,13 +87,13 @@ public class ViewCellAdapter extends RecyclerView.Adapter<BaseViewHolder> implem
     }
 
     @Override
-    public BaseViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         return viewCellTypes.get(viewType).createViewHolder(parent);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public void onBindViewHolder(BaseViewHolder holder, int position) {
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         AbstractViewCell viewCell = ViewCellUtils.getViewCell(sections, position);
 
         ListenerBinderHelper.bindListenersTo(viewCell, holder, listenerCollection);

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/ViewCellAdapter.java
@@ -96,8 +96,9 @@ public class ViewCellAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         AbstractViewCell viewCell = ViewCellUtils.getViewCell(sections, position);
 
-        ListenerBinderHelper.bindListenersTo(viewCell, holder, listenerCollection);
+        viewCell.unbindViewCell(holder);
         viewCell.bindViewCell(holder);
+        ListenerBinderHelper.bindListenersTo(viewCell, holder, listenerCollection);
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/construction/CompositeSectionBuilder.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/construction/CompositeSectionBuilder.java
@@ -16,4 +16,9 @@ public class CompositeSectionBuilder extends SectionBuilder<CompositeSection> {
         getSection().addSection(section);
         return this;
     }
+
+    public CompositeSectionBuilder section(SectionBuilder sectionBuilder) {
+        getSection().addSection(sectionBuilder.build());
+        return this;
+    }
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/construction/SectionBuilder.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/construction/SectionBuilder.java
@@ -1,5 +1,7 @@
 package ca.antonious.viewcelladapter.construction;
 
+import android.support.v7.widget.RecyclerView;
+
 import ca.antonious.viewcelladapter.decorators.ItemDividerSectionDecorator;
 import ca.antonious.viewcelladapter.internal.Function;
 import ca.antonious.viewcelladapter.decorators.EmptySectionDecorator;
@@ -7,6 +9,7 @@ import ca.antonious.viewcelladapter.decorators.FooterSectionDecorator;
 import ca.antonious.viewcelladapter.decorators.HeaderSectionDecorator;
 import ca.antonious.viewcelladapter.decorators.SectionDecorator;
 import ca.antonious.viewcelladapter.sections.AbstractSection;
+import ca.antonious.viewcelladapter.sections.AdapterWrapperSection;
 import ca.antonious.viewcelladapter.sections.CompositeSection;
 import ca.antonious.viewcelladapter.sections.HomogeneousSection;
 import ca.antonious.viewcelladapter.viewcells.AbstractViewCell;
@@ -35,9 +38,13 @@ public class SectionBuilder<TSection extends AbstractSection> {
     public static <TSection extends AbstractSection> SectionBuilder<TSection> wrap(TSection section) {
         return new SectionBuilder<>(section);
     }
-
+    
     public static <TModel, TViewCell extends GenericViewCell<?, TModel>> HomogeneousSectionBuilder<TModel, TViewCell> wrap(HomogeneousSection<TModel, TViewCell> section) {
         return new HomogeneousSectionBuilder<>(section);
+    }
+
+    public static <TViewHolder extends RecyclerView.ViewHolder> SectionBuilder<AdapterWrapperSection<TViewHolder>> wrap(RecyclerView.Adapter<TViewHolder> adapter) {
+        return new SectionBuilder<>(new AdapterWrapperSection<>(adapter));
     }
 
     public static CompositeSectionBuilder createCompositeSection() {

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/construction/ViewCellAdapterBuilder.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/construction/ViewCellAdapterBuilder.java
@@ -19,6 +19,11 @@ public class ViewCellAdapterBuilder {
         return this;
     }
 
+    public ViewCellAdapterBuilder section(SectionBuilder sectionBuilder) {
+        viewCellAdapter.add(sectionBuilder.build());
+        return this;
+    }
+
     public ViewCellAdapterBuilder listener(Object listener) {
         viewCellAdapter.addListener(listener);
         return this;

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/EmptySectionDecorator.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/EmptySectionDecorator.java
@@ -24,13 +24,6 @@ public class EmptySectionDecorator extends SectionDecorator {
     }
 
     @Override
-    public void remove(int position) {
-        if (!getDecoratedSection().isEmpty()) {
-            getDecoratedSection().remove(position);
-        }
-    }
-
-    @Override
     public int getItemCount() {
         if (getDecoratedSection().isEmpty()) {
             return 1;

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/FooterSectionDecorator.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/FooterSectionDecorator.java
@@ -25,11 +25,6 @@ public class FooterSectionDecorator extends SectionDecorator {
     }
 
     @Override
-    public void remove(int position) {
-        getDecoratedSection().remove(position);
-    }
-
-    @Override
     public int getItemCount() {
         if (isSectionEmpty()) {
             return 0;

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/HeaderSectionDecorator.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/HeaderSectionDecorator.java
@@ -25,11 +25,6 @@ public class HeaderSectionDecorator extends SectionDecorator {
     }
 
     @Override
-    public void remove(int position) {
-        getDecoratedSection().remove(position - 1);
-    }
-
-    @Override
     public int getItemCount() {
         if (isSectionEmpty()) {
             return 0;

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/ItemDividerSectionDecorator.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/decorators/ItemDividerSectionDecorator.java
@@ -27,13 +27,6 @@ public class ItemDividerSectionDecorator extends SectionDecorator {
     }
 
     @Override
-    public void remove(int position) {
-        if (position % 2 == 0) {
-            getDecoratedSection().remove(getInnerPosition(position));
-        }
-    }
-
-    @Override
     public int getItemCount() {
         return getDecoratedSection().getItemCount() + getTotalDividers();
     }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/AbstractSection.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/AbstractSection.java
@@ -46,7 +46,6 @@ public abstract class AbstractSection {
     }
 
     public abstract AbstractViewCell get(int position);
-    public abstract void remove(int position);
     public abstract int getItemCount();
 
     public static class AbstractSectionIterator implements Iterator<AbstractViewCell> {

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/AdapterWrapperSection.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/AdapterWrapperSection.java
@@ -1,0 +1,90 @@
+package ca.antonious.viewcelladapter.sections;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.ViewGroup;
+
+import ca.antonious.viewcelladapter.viewcells.AbstractViewCell;
+
+/**
+ * Created by George on 2017-07-05.
+ */
+
+public class AdapterWrapperSection<TViewHolder extends RecyclerView.ViewHolder> extends AbstractSection {
+    private RecyclerView.Adapter<TViewHolder> adapter;
+
+    public AdapterWrapperSection(RecyclerView.Adapter<TViewHolder> adapter) {
+        this.adapter = adapter;
+        this.adapter.registerAdapterDataObserver(new AdapterObserver());
+    }
+
+    @Override
+    public AbstractViewCell get(int position) {
+        return new AdapterViewCell(position);
+    }
+
+    @Override
+    public int getItemCount() {
+        return adapter.getItemCount();
+    }
+
+    public class AdapterViewCell extends AbstractViewCell<TViewHolder> {
+        private int position;
+
+        public AdapterViewCell(int position) {
+            this.position = position;
+        }
+
+        @Override
+        public int getItemId() {
+            return (int) adapter.getItemId(position);
+        }
+
+        @Override
+        public void bindViewCell(TViewHolder viewHolder) {
+            adapter.bindViewHolder(viewHolder, position);
+        }
+
+        @Override
+        public TViewHolder createViewHolder(ViewGroup parent) {
+            return adapter.createViewHolder(parent, adapter.getItemViewType(position));
+        }
+    }
+
+    public class AdapterObserver extends RecyclerView.AdapterDataObserver {
+        @Override
+        public void onChanged() {
+            super.onChanged();
+            notifyDataChanged();
+        }
+
+        @Override
+        public void onItemRangeChanged(int positionStart, int itemCount) {
+            super.onItemRangeChanged(positionStart, itemCount);
+            notifyDataChanged();
+        }
+
+        @Override
+        public void onItemRangeChanged(int positionStart, int itemCount, Object payload) {
+            super.onItemRangeChanged(positionStart, itemCount, payload);
+            notifyDataChanged();
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            super.onItemRangeInserted(positionStart, itemCount);
+            notifyDataChanged();
+        }
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            super.onItemRangeRemoved(positionStart, itemCount);
+            notifyDataChanged();
+        }
+
+        @Override
+        public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+            super.onItemRangeMoved(fromPosition, toPosition, itemCount);
+            notifyDataChanged();
+        }
+    }
+}

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/CompositeSection.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/CompositeSection.java
@@ -24,14 +24,6 @@ public class CompositeSection extends AbstractSection implements SectionObserver
     }
 
     @Override
-    public void remove(int position) {
-        int sectionIndex = ViewCellUtils.getSectionIndex(sections, position);
-        int viewCellIndex = ViewCellUtils.getViewCellIndex(sections, position);
-
-        sections.get(sectionIndex).remove(viewCellIndex);
-    }
-
-    @Override
     public int getItemCount() {
         return ViewCellUtils.getTotalCount(sections);
     }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/HomogeneousSection.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/HomogeneousSection.java
@@ -90,6 +90,14 @@ public class HomogeneousSection<TModel, TViewCell extends GenericViewCell<?, TMo
         invalidateData();
     }
 
+    public void remove(int position) {
+        TViewCell viewCellToRemove = viewCellsToRender.get(position);
+        viewCells.remove(viewCellToRemove);
+
+        invalidateData();
+    }
+
+
     public void clear() {
         viewCells.clear();
         invalidateData();
@@ -171,14 +179,6 @@ public class HomogeneousSection<TModel, TViewCell extends GenericViewCell<?, TMo
     @Override
     public AbstractViewCell get(int position) {
         return viewCellsToRender.get(position);
-    }
-
-    @Override
-    public void remove(int position) {
-        TViewCell viewCellToRemove = viewCellsToRender.get(position);
-        viewCells.remove(viewCellToRemove);
-
-        invalidateData();
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/Section.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/sections/Section.java
@@ -54,6 +54,11 @@ public class Section extends AbstractSection {
         invalidateData();
     }
 
+    public void remove(int position) {
+        viewCells.remove(position);
+        invalidateData();
+    }
+
     public void clear() {
         viewCells.clear();
         invalidateData();
@@ -62,12 +67,6 @@ public class Section extends AbstractSection {
     @Override
     public AbstractViewCell get(int position) {
         return viewCells.get(position);
-    }
-
-    @Override
-    public void remove(int position) {
-        viewCells.remove(position);
-        invalidateData();
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
@@ -50,6 +50,10 @@ public abstract class AbstractViewCell<TViewHolder extends RecyclerView.ViewHold
         return 1;
     }
 
+    public void unbindViewCell(TViewHolder viewHolder) {
+
+    }
+
     public View createView(ViewGroup parent) {
         return inflate(parent, getLayoutId());
     }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
@@ -1,6 +1,7 @@
 package ca.antonious.viewcelladapter.viewcells;
 
 import android.support.annotation.LayoutRes;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,7 +13,7 @@ import java.lang.reflect.ParameterizedType;
  * Created by George on 2016-11-17.
  */
 
-public abstract class AbstractViewCell<TViewHolder extends BaseViewHolder> implements Selectable {
+public abstract class AbstractViewCell<TViewHolder extends RecyclerView.ViewHolder> implements Selectable {
     private boolean isSelected;
 
     public AbstractViewCell() {

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/AbstractViewCell.java
@@ -1,11 +1,12 @@
 package ca.antonious.viewcelladapter.viewcells;
 
+import android.support.annotation.LayoutRes;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.ParameterizedType;
-
-import ca.antonious.viewcelladapter.internal.Function;
 
 /**
  * Created by George on 2016-11-17.
@@ -18,7 +19,6 @@ public abstract class AbstractViewCell<TViewHolder extends BaseViewHolder> imple
         this.isSelected = false;
     }
 
-    public abstract int getLayoutId();
     public abstract int getItemId();
     public abstract void bindViewCell(TViewHolder viewHolder);
 
@@ -37,12 +37,37 @@ public abstract class AbstractViewCell<TViewHolder extends BaseViewHolder> imple
         isSelected = false;
     }
 
+    public int getLayoutId() {
+        return -1;
+    }
+
+    public int getViewType() {
+        return getClass().getCanonicalName().hashCode();
+    }
+
     public int getTotalPerLine() {
         return 1;
     }
 
-    public Function<View, BaseViewHolder> getViewHolderFactory() {
-        return new ReflectionBasedViewHolderFactory(getViewHolderClass());
+    public View createView(ViewGroup parent) {
+        return inflate(parent, getLayoutId());
+    }
+
+    public TViewHolder createViewHolder(View view) {
+        try {
+            Constructor<? extends TViewHolder> viewHolderConstructor = getViewHolderClass().getConstructor(View.class);
+            return viewHolderConstructor.newInstance(view);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public TViewHolder createViewHolder(ViewGroup parent) {
+        return createViewHolder(createView(parent));
+    }
+
+    public View inflate(ViewGroup parent, @LayoutRes int layoutId) {
+        return LayoutInflater.from(parent.getContext()).inflate(layoutId, parent, false);
     }
 
     @SuppressWarnings("unchecked")
@@ -51,21 +76,5 @@ public abstract class AbstractViewCell<TViewHolder extends BaseViewHolder> imple
                 .getGenericSuperclass()).getActualTypeArguments()[0];
     }
 
-    public static class ReflectionBasedViewHolderFactory implements Function<View, BaseViewHolder> {
-        private Class<? extends BaseViewHolder> viewHolderClass;
 
-        public ReflectionBasedViewHolderFactory(Class<? extends BaseViewHolder> viewHolderClass) {
-            this.viewHolderClass = viewHolderClass;
-        }
-
-        @Override
-        public BaseViewHolder apply(View view) {
-            try {
-                Constructor<? extends BaseViewHolder> viewHolderConstructor = viewHolderClass.getConstructor(View.class);
-                return viewHolderConstructor.newInstance(view);
-            } catch (Exception e) {
-                return null;
-            }
-        }
-    }
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/GenericViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/GenericViewCell.java
@@ -1,10 +1,12 @@
 package ca.antonious.viewcelladapter.viewcells;
 
+import android.support.v7.widget.RecyclerView;
+
 /**
  * Created by George on 2016-11-17.
  */
 
-public abstract class GenericViewCell<TViewHolder extends BaseViewHolder, TModel> extends AbstractViewCell<TViewHolder> {
+public abstract class GenericViewCell<TViewHolder extends RecyclerView.ViewHolder, TModel> extends AbstractViewCell<TViewHolder> {
     private TModel model;
 
     public GenericViewCell(TModel model) {

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/BaseMaterialSettingViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/BaseMaterialSettingViewCell.java
@@ -1,12 +1,12 @@
 package ca.antonious.viewcelladapter.viewcells.builtins;
 
+import android.support.v7.widget.RecyclerView;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.TextView;
 
 import ca.antonious.viewcelladapter.R;
 import ca.antonious.viewcelladapter.viewcells.AbstractViewCell;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 
 /**
  * Created by George on 2017-04-29.
@@ -36,7 +36,7 @@ public abstract class BaseMaterialSettingViewCell<TViewCell extends BaseMaterial
         return settingId;
     }
 
-    public static class BaseMaterialSettingViewHolder extends BaseViewHolder {
+    public static class BaseMaterialSettingViewHolder extends RecyclerView.ViewHolder {
         private TextView labelTextView;
         private TextView secondaryTextTextView;
 

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialLabelViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialLabelViewCell.java
@@ -6,7 +6,6 @@ import android.view.View;
 import android.widget.TextView;
 
 import ca.antonious.viewcelladapter.R;
-import ca.antonious.viewcelladapter.internal.Function;
 import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 import ca.antonious.viewcelladapter.viewcells.GenericViewCell;
 

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialLabelViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialLabelViewCell.java
@@ -36,13 +36,8 @@ public class MaterialLabelViewCell extends GenericViewCell<MaterialLabelViewCell
     }
 
     @Override
-    public Function<View, BaseViewHolder> getViewHolderFactory() {
-        return new Function<View, BaseViewHolder>() {
-            @Override
-            public BaseViewHolder apply(View view) {
-                return new MaterialLabelViewHolder(view);
-            }
-        };
+    public MaterialLabelViewHolder createViewHolder(View view) {
+        return new MaterialLabelViewHolder(view);
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialSettingsItemViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialSettingsItemViewCell.java
@@ -4,8 +4,6 @@ import android.view.View;
 
 import ca.antonious.viewcelladapter.R;
 import ca.antonious.viewcelladapter.annotations.BindListener;
-import ca.antonious.viewcelladapter.internal.Function;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 
 /**
  * Created by George on 2017-04-29.

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialSettingsItemViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialSettingsItemViewCell.java
@@ -30,13 +30,8 @@ public class MaterialSettingsItemViewCell extends BaseMaterialSettingViewCell<Ma
     }
 
     @Override
-    public Function<View, BaseViewHolder> getViewHolderFactory() {
-        return new Function<View, BaseViewHolder>() {
-            @Override
-            public BaseViewHolder apply(View view) {
-                return new MaterialSettingsItemViewHolder(view);
-            }
-        };
+    public MaterialSettingsItemViewHolder createViewHolder(View view) {
+        return new MaterialSettingsItemViewHolder(view);
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialToggleSettingViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialToggleSettingViewCell.java
@@ -1,16 +1,11 @@
 package ca.antonious.viewcelladapter.viewcells.builtins;
 
-import android.util.TypedValue;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.Switch;
-import android.widget.TextView;
 
 import ca.antonious.viewcelladapter.R;
 import ca.antonious.viewcelladapter.annotations.BindListener;
-import ca.antonious.viewcelladapter.internal.Function;
-import ca.antonious.viewcelladapter.viewcells.AbstractViewCell;
-import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 
 /**
  * Created by George on 2017-04-26.

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialToggleSettingViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/MaterialToggleSettingViewCell.java
@@ -44,13 +44,8 @@ public class MaterialToggleSettingViewCell extends BaseMaterialSettingViewCell<M
     }
 
     @Override
-    public Function<View, BaseViewHolder> getViewHolderFactory() {
-        return new Function<View, BaseViewHolder>() {
-            @Override
-            public BaseViewHolder apply(View view) {
-                return new MaterialToggleSettingViewHolder(view);
-            }
-        };
+    public MaterialToggleSettingViewHolder createViewHolder(View view) {
+        return new MaterialToggleSettingViewHolder(view);
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/StaticViewCell.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/builtins/StaticViewCell.java
@@ -37,13 +37,8 @@ public class StaticViewCell extends AbstractViewCell<BaseViewHolder> {
     }
 
     @Override
-    public Function<View, BaseViewHolder> getViewHolderFactory() {
-        return new Function<View, BaseViewHolder>() {
-            @Override
-            public BaseViewHolder apply(View input) {
-                return new BaseViewHolder(input);
-            }
-        };
+    public BaseViewHolder createViewHolder(View view) {
+        return new BaseViewHolder(view);
     }
 
     @Override

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/eventhandling/ListenerBinder.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/eventhandling/ListenerBinder.java
@@ -1,5 +1,7 @@
 package ca.antonious.viewcelladapter.viewcells.eventhandling;
 
+import android.support.v7.widget.RecyclerView;
+
 import ca.antonious.viewcelladapter.viewcells.AbstractViewCell;
 import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
 
@@ -7,6 +9,6 @@ import ca.antonious.viewcelladapter.viewcells.BaseViewHolder;
  * Created by George on 2016-12-28.
  */
 
-public interface ListenerBinder<TViewCell extends AbstractViewCell<TViewHolder>, TViewHolder extends BaseViewHolder> {
+public interface ListenerBinder<TViewCell extends AbstractViewCell<TViewHolder>, TViewHolder extends RecyclerView.ViewHolder> {
     void bindListeners(TViewCell viewCell, TViewHolder viewHolder, ListenerCollection listenerCollection);
 }

--- a/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/eventhandling/ListenerBinderHelper.java
+++ b/viewcelladapter/src/main/java/ca/antonious/viewcelladapter/viewcells/eventhandling/ListenerBinderHelper.java
@@ -1,5 +1,7 @@
 package ca.antonious.viewcelladapter.viewcells.eventhandling;
 
+import android.support.v7.widget.RecyclerView;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -17,7 +19,7 @@ public class ListenerBinderHelper {
     private static Map<Class<?>, Set<ListenerBinder>> listenerBinderMappings = new HashMap<>();
 
     @SuppressWarnings("unchecked")
-    public static void bindListenersTo(AbstractViewCell viewCell, BaseViewHolder viewHolder, ListenerCollection listeners) {
+    public static void bindListenersTo(AbstractViewCell viewCell, RecyclerView.ViewHolder viewHolder, ListenerCollection listeners) {
         for (ListenerBinder listenerBinder: getListenerBindersFor(viewCell.getClass())) {
             listenerBinder.bindListeners(viewCell, viewHolder, listeners);
         }

--- a/viewcelladapter/src/test/java/ca/antonious/viewcelladapter/sectiontests/CompositeSectionTests.java
+++ b/viewcelladapter/src/test/java/ca/antonious/viewcelladapter/sectiontests/CompositeSectionTests.java
@@ -84,29 +84,4 @@ public class CompositeSectionTests {
 
         assertEquals(expectedViewCell, actualViewCell);
     }
-
-    @Test
-    public void test_removeItem() {
-        AbstractViewCell section1Item1 = new TestViewCell("SECTION1:ITEM1");
-        AbstractViewCell section1Item2 = new TestViewCell("SECTION1:ITEM2");
-        AbstractViewCell section2Item1 = new TestViewCell("SECTION2:ITEM1");
-
-        Section section1 = new Section();
-        section1.add(section1Item1);
-        section1.add(section1Item2);
-
-        Section section2 = new Section();
-        section2.add(section2Item1);
-
-        CompositeSection compositeSection = new CompositeSection()
-                .addSection(section1)
-                .addSection(section2);
-
-        compositeSection.remove(0);
-
-        AbstractViewCell expectedViewCell = section1Item2;
-        AbstractViewCell actualViewCell = compositeSection.get(0);
-
-        assertEquals(expectedViewCell, actualViewCell);
-    }
 }


### PR DESCRIPTION
**Breaking changes**

- Anywhere where a viewHolderFactory is returned should be replaced by overriding `createViewHolder(View view)` in the respective `ViewCell`
- `ViewCellAdapter` no longer has a `remove(int index)` method and `abstract remove(int index)` was removed from `AbstractSection`. Section implementations will need to remove `@Override` on `remove(int index)` and consumers can no longer assume remove exists

**Features**

- Added `AdapterWrapperSection` which can take in any `RecyclerView.Adapter` implementation and adapt it to the `Section` API.
- Added `unbindViewCell(TViewHolder viewHolder)` callback to `AbstractViewCell` to make room for clean up logic. Mainly for cleaning up dangling listeners in a viewholder.